### PR TITLE
gtest 1.13 need c++14

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CXX?=g++
-CXXFLAGS+=-Wall -std=c++11 `pkg-config --cflags gtest_main`
+CXXFLAGS+=-Wall -std=c++14 `pkg-config --cflags gtest_main`
 LDFLAGS+=`pkg-config --libs gtest_main`
 
 OBJS=ts-roundtrip.o ts-snippets.o ts-utf8.o ts-bugfix.o ts-quotes.o ts-noconvert.o


### PR DESCRIPTION
Ubuntu gtest package is still in 1.11, but downloading 1.13 from https://github.com/google/googletest throws an error saying `gtest-port.h:270:2: error: #error C++ versions less than C++14 are not supported.`