### PR TITLE
add conversion instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # This makefile is just to build the automatic test harness
-# To use SimpleIni, just include SimpleIni.h header file 
+# To use SimpleIni, just include SimpleIni.h header file and define SI_NO_CONVERSION.
+# If you need convertion, include ConvertUTF.h with ConvertUTF.c
 
 PREFIX?=	/usr/local
 
@@ -16,3 +17,5 @@ $(SUBDIRS):
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/include/
 	install -C -m 644 SimpleIni.h $(DESTDIR)$(PREFIX)/include/
+	install -C -m 644 ConvertUTF.h $(DESTDIR)$(PREFIX)/include/
+	install -C -m 644 ConvertUTF.c $(DESTDIR)$(PREFIX)/include/


### PR DESCRIPTION
At first I just looked into this Makefile, ran `make install` and it copied only `SimpleIni.h` into my project. When I built it, it gave me this error `SimpleIni/SimpleIni.h:3014:10: fatal error: ConvertUTF.h: No such file or directory`. Then I read `SimpleIni.h` USAGE section and learned about `SI_NO_CONVERSION`. I guess it is simpler to just have `install` copying the convert files.

Another option would be to tell user to include all files without explanation, or point user to `SimpleIni.h` USAGE section...